### PR TITLE
Create release workflow to publish package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,20 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - 'v[0-9]+'
+
+jobs:
+  publish-releases:
+    name: Publish Releases
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Publish Releases
+      uses: thefrontside/actions/synchronize-with-npm@v1.6
+      with:
+        npm_publish: yarn publish
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        NPM_TOKEN: ${{ secrets.FRONTSIDEJACK_NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "graphgen",
+  "name": "@thefrontside/graphgen",
   "version": "1.0.0",
   "description": "Graph Generator",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@thefrontside/graphgen",
+  "name": "@frontside/graphgen",
   "version": "1.0.0",
   "description": "Graph Generator",
   "main": "dist/index.js",


### PR DESCRIPTION
## Motivation

Set up release workflow to publish package to NPM

## Approach

- Added Jack's NPM token to secrets
- Rename package to `@thefrontside/graphgen`
- Add release workflow

## Notes

- ⚠️ I forget if this action errors if it tries to publish a package for the first time. If merging this PR fails the publishing action, we will need to publish it manually using Jack.