### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,9 +13,6 @@ jobs:
     - uses: actions/checkout@v1
     - name: Publish Release
       uses: thefrontside/actions/synchronize-with-npm@v1.9
-      with:
-        before_all: yarn prepack
-        npm_publish: yarn publish
       env:
         GITHUB_TOKEN: ${{ secrets.FRONTSIDEJACK_GITHUB_TOKEN }}
         NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@frontside/graphgen",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Graph Generator",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Motivation

#9 - i'll close the issue if the publish is successful

## Approach

- Removed the `publish` and `before_all` arguments so now it'll run `npm publish` by default and it will run `prepack` automatically before the publish takes place.
- Bumped patch to trigger publish.
- Added empty `.npmignore` to see if that'll include all the files in the `dist/` directory.