### PR TITLE
Add concept of relationship affinity

### DIFF
--- a/test/cyclic.test.ts
+++ b/test/cyclic.test.ts
@@ -46,4 +46,48 @@ describe('cyclic references', () => {
       expect(back).toEqual(user);
     });
   });
+
+  describe('cyclic relationships', () => {
+    beforeEach(() => {
+      graph = createGraph({
+        types: {
+          vertex: [{
+            name: "User",
+            relationships: [{
+              type: "User.repositories",
+              direction: "from",
+              size: constant(3),
+            }],
+          }, {
+            name: "Repository",
+            relationships: [{
+              type: "Repository.collaborators",
+              direction: "from",
+              size: constant(2),
+            }, {
+              type: "User.repositories",
+              direction: "to",
+              size: constant(1),
+            }],
+          }],
+          edge: [{
+            name: "User.repositories",
+            from: "User",
+            to: "Repository",
+          }, {
+            name: "Repository.collaborators",
+            from: "Repository",
+            to: "User",
+          }],
+        },
+      });
+    });
+
+    it('converges on a state of re-using existing vertices', () => {
+      let user = createVertex(graph, "User");
+      let [repository] = graph.from[user.id].map((edge) => graph.vertices[edge.to]);
+      let [collaborator] = graph.from[repository.id].map((edge) => graph.vertices[edge.to]);
+      expect(collaborator).toBeDefined();
+    });
+  });
 });


### PR DESCRIPTION
## Motivation
When generating a cyclic interwoven graph, it is almost certainly possible for it to "explode". That is, if You have a relationship:

```
A -> B[]
B -> A[]
```

Then generating an `A` will generate some number of `B`s. Those `B`s in turn, will generate `A`s, which then generate `B`s ad infinitum. This is problematic because almost any realistic representation of the world will have cyclic references.

## Approach

To fix this, we introduce the concept of "affinity" That is, what is the likelihood of a relationship being satisfied by an existing vertex rather than requiring the creation of an entirely new vertex given the size of the target population. Consider networks of people. As someone is created as part of the generation, what is the liklihood that their friends will already exist? The answer is "it depends". Specifically, it depends on how many people there are out there. As the population of people grows, it becomes increasingly more likely that we can find their list of friends from the pool of existing people.

For example, an affinity of 1% in the "friend" relationship, means that there is a 1% chance that two people will be friends. So, when we geneate a person's friends, if there is only one other person in the world, the chance that they are the friends is `0.01`. Very low (but possible), so most of the time we choose to generate. If there are 3 other people in the world, then it becomes more likely, and if there are 10,000 people in the world, the chance that this person already exists is almost certain.

It should be noted that this concept of affinity is a blunt tool that will result in correctly formed, and most importantly _convergent_ graph generations that will eventually stabilize to choose only from existing populations. However, it does not help very much in grouping clumps of the network together. For example, if someone is from Mexico, their affinity will be lower for the general population of people, and higher for the population of people who are also from Mexico. This is still impossible to represent, and so the mechanism for affinity may need to change in the future in part, or entirely in order to account for it.

## Learning

Inspiration for this solution was taken from the birthday problem https://en.wikipedia.org/wiki/Birthday_problem