### PR TITLE
Set default affinity to zero.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -210,7 +210,7 @@ export function createVertex(graph: Graph, typeName: string, preset?: unknown, i
       // as the population of targets grows, it becomes more likely that we will
       // select an existing one. The default affinity is 1%
       let affinity = 1 -
-        Math.pow(1 - (relationship.affinity ?? 0.01), population.length);
+        Math.pow(1 - (relationship.affinity ?? 0), population.length);
 
       let [targetId, exists] = (function(): [number, boolean] {
         if (population.length > excluded.length && graph.seed() < affinity) {

--- a/test/cyclic.test.ts
+++ b/test/cyclic.test.ts
@@ -64,6 +64,7 @@ describe('cyclic references', () => {
               type: "Repository.collaborators",
               direction: "from",
               size: constant(2),
+              affinity: 0.01,
             }, {
               type: "User.repositories",
               direction: "to",


### PR DESCRIPTION
## Motivation
Having affinity is important for circular relationships, but for directed relationships you almost always want to have a unique target. For example, if you have a person that has a github account, then you want their github account to be unique. The introduction of the concept of graph affinity also saw the introduction of a default affinity for _all_ relationships. This is counter-intuitive, and clearly backwards compatible because it breaks the behavior of current generations by making formerly unique relationships shared between vertices.

## Approach
This makes the default affinity 0 in order to preserve existing behavior, and as a result circular relationships can still blow up and must be clearly annotated with a value for affinity.
