### PR TITLE
Allow generating multiple relationships from a vertex

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@frontside/graphgen",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Graph Generator",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -178,7 +178,11 @@ export function createVertex(graph: Graph, typeName: string, preset?: unknown, i
 
     let [size, presets] = allocateRelated();
 
-    let existing = graph[relationship.direction][id] || [];
+    // these are the relationships of this typethat already exist both to and
+    // from this vertex
+    let existing = (graph[relationship.direction][id] || [])
+                     .filter(rel => rel.type === relationship.type);
+
     let excluded = [source.id];
 
     for (let i = existing.length; i < size; i++) {

--- a/test/graphgen.test.ts
+++ b/test/graphgen.test.ts
@@ -149,4 +149,47 @@ describe("graph generation", () => {
       expect(graph.to[first.id].length).toEqual(1);
     });
   });
+
+  describe("generating multiple relationships from a single node", () => {
+    let graph: Graph;
+    let article: Vertex;
+
+    beforeEach(() => {
+      graph = createGraph({
+        types: {
+          edge: [{
+            name: 'author',
+            from: 'Article',
+            to: 'User'
+          }, {
+            name: 'editor',
+            from: 'Article',
+            to: 'User'
+          }],
+          vertex: [{
+            name: 'Article',
+            relationships: [{
+              type: 'author',
+              direction: 'from',
+              size: constant(1),
+            }, {
+              type: 'editor',
+              direction: 'from',
+              size:  constant(1)
+            }],
+          }, {
+            name: 'User',
+            relationships: []
+          }]
+        },
+
+      });
+
+      article = createVertex(graph, 'Article');
+    });
+
+    it("creates edges for each relationship type", () => {
+      expect(graph.from[article.id]).toHaveLength(2);
+    });
+  });
 });


### PR DESCRIPTION
## Motivation

There is really nasty bug where a vertex counts the number of _existing_ edges towards the size limit of how many it wants to generate. So, for example, if we have a user with two friends, and then we generate a set of articles that this person has written (Let's say that graphgen decides it should be three articles). It will count the two friend relationships towards the article total, and instead of generating three articles, it will only generate one. This is especially pernicious with `constant` relationships of one, since if there is any other edge connecting that vertex, it will not be generated.

## Approach
The answer is only use existing edges _of the same edge type_ towards the total number of edges that already exist.