### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,9 +10,9 @@ jobs:
     name: Publish Release
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Publish Release
-      uses: thefrontside/actions/synchronize-with-npm@v1.9
+      uses: thefrontside/actions/synchronize-with-npm@v1
       env:
         GITHUB_TOKEN: ${{ secrets.FRONTSIDEJACK_GITHUB_TOKEN }}
         NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Motivation

Release workflow for `graphgen@1.3.2` [failed](https://github.com/thefrontside/graphgen/runs/6095613608?check_suite_focus=true) because of a recent change to git

## Approach

- Created fix in actions repo
- Updated release workflow to call the action from `v1` and to use `v3` of actions/checkout

## TODOs

- [x] Merge [`thefrontside/actions`' #73](https://github.com/thefrontside/actions/pull/73) first