### PR TITLE
✨Allow generations to go from->to and to->from

### DIFF
--- a/test/cyclic.test.ts
+++ b/test/cyclic.test.ts
@@ -46,6 +46,18 @@ describe("cyclic references", () => {
 
       expect(back).toEqual(user);
     });
+
+    it("can begin generation from the owned vertex", () => {
+      let repo = createVertex(graph, "Repository");
+
+      expect(graph.to[repo.id]).toBeDefined();
+
+      let [user] = graph.to[repo.id].map((edge) => graph.vertices[edge.from]);
+
+      let [back] = graph.from[user.id].map((edge) => graph.vertices[edge.to]);
+
+      expect(back).toEqual(repo);
+    });
   });
 
   describe("cyclic relationships", () => {


### PR DESCRIPTION
## Motivation
Graphgen lets you generate networks of data. How does it do this? There are vertices representing individual things that have an identity, and then there are edges in between those vertices that represent relationships between these things. Whenever we are generating a vertex, we create its properties, and then we generate its relationships which means creating edges, and then, if necessary, generating the vertices on the other end of those edges.

To use GitHub as an example, if we have a `User` that has a list of repositories that they own, we add an relationship "from" `User` and "to" `Repository`. We could name this `User.repositories` Thus, when we generate a user, we will also generate a list of `Repository`s that sit on the other end of that User.repositories.

What happens though when have multiple relationships connecting `User` and `Repository`? Let's say that not only can a user own many repositories, but they can also collaborate on many repositories as well. Let's say that we have now `User.collaboratesOn` in addition to `User.repositories`. Assume the following sequence:

1. Generate User.
2. Generate 1 collaborated repositories
3. !! missing step!! the collaborated repository should generate an
owner specified by the `User.repositories` relationship (which may
then generate more collaborated repositories.)
4. Generate 3 owned repositories

Most of the time the graph is generated in a single direction: "from"
-> "to" but in these cases, we also need to generated "to" -> "from"
So that we can generate the `User.repositories` relationship no matter
whether we approach the edge from the repository side or the user
side.

## Approach

This change allows relationships to be generated no matter which side of the edge the traversal begins with. After all, the designations "from" and "to" are really totally arbitrary and could just as well as be called "left" and "right", "a", and "b", or "Gladys" and "Gertrude".