### PR TITLE
don't call computed for preset properties

### DIFF
--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -8,8 +8,6 @@ import { DispatchArg } from "./dispatch.ts";
 
 export * from "./dispatch.ts";
 
-type EmptyObject = Record<never, never>;
-
 export interface Node {
   id: string;
 }
@@ -137,7 +135,7 @@ directive @computed on FIELD_DEFINITION
 
   let nodes = {} as Record<number, Node>;
 
-  function toNode<T>(vertex: Vertex, preset: API | EmptyObject = {}): Node & T {
+  function toNode<T>(vertex: Vertex): Node & T {
     let existing = nodes[vertex.id];
     if (existing) {
       return existing as Node & T;
@@ -174,9 +172,7 @@ directive @computed on FIELD_DEFINITION
 
       Object.defineProperties(node, properties);
 
-      let presetKeys = Object.keys(preset);
-
-      let computed = type.computed.filter(compute => !presetKeys.includes(compute.name)).reduce((props, compute) => {
+      let computed = type.computed.filter(compute => !vertex.data[compute.name]).reduce((props, compute) => {
         return {
           ...props,
           [compute.name]: {
@@ -239,7 +235,7 @@ directive @computed on FIELD_DEFINITION
   ): Node & API[T] {
     let type = expect(typename, types, `unknown type '${typename}'`);
     let vertex = createVertex(graph, typename, transform(type, preset as Record<string, unknown>));
-    return toNode(vertex, preset) as Node & API[typeof typename];
+    return toNode(vertex) as Node & API[typeof typename];
   }
 
   return {

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -48,7 +48,7 @@ type DefaultComputeMap = Record<string, (node: any) => any>;
 
 type ComputeMap<API> = {
   [K in keyof API]: {
-    [P in keyof API[K] as `${K & string}.${P & string}`]: (o: API[K]) => any;
+    [P in keyof API[K] as `${K & string}.${P & string}`]?: (o: API[K]) => any;
   }
 }[keyof API];
 
@@ -182,7 +182,7 @@ directive @computed on FIELD_DEFINITION
           [compute.name]: {
             enumerable: true,
             get() {
-              let map: DefaultComputeMap = options.compute ?? {};
+              let map = (options.compute ?? {}) as DefaultComputeMap;
               let computer = map[compute.key];
               if (computer) {
                 return computer(this);

--- a/test/graphql.test.ts
+++ b/test/graphql.test.ts
@@ -271,6 +271,23 @@ type Person { firstName: String! lastName: String! name: String! @computed }
     expect(person.name).toEqual("firstName lastName");
   });
 
+  it("does not call computed for properties that exist in the preset", () => {
+    let person = createGraphGen({
+      source: `
+type Person { firstName: String! lastName: String! name: String! @computed }
+`,
+      generate(info) {
+        return info.fieldname;
+      },
+      compute: {
+        "Person.name": (person: Record<string, unknown>) =>
+          `${person.firstName} ${person.lastName}`,
+      },
+    }).create("Person", { firstName: 'Sue', lastName: 'Barker', name: "Bob Jones" });
+    
+    expect(person.name).toEqual("Bob Jones");    
+  });
+
   it("is an error to mark a field as @computed without also having a computation in the compute map", () => {
     expect(() =>
       createGraphGen({


### PR DESCRIPTION
## Motivation

If a preset is given, e.g.

```ts
    factory.create('Employee', {
      firstName: 'admin',
      lastName: 'admin',
      email: 'admin@hp.com',
```

and a computed rule exists for one of the preset properties

```ts
compute: {
  'Employee.email': employee => `${employee.firstName}.${employee.lastName}@frontside.com`.toLowerCase(),
```

Then the computed overrides the preset and it is impossible to guarantee data generation of known fields.

## Approach

Don't create a `computed` property for property keys that exist in the preset.