### PR TITLE
filter by vertex.data keys

### DIFF
--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -172,7 +172,11 @@ directive @computed on FIELD_DEFINITION
 
       Object.defineProperties(node, properties);
 
-      let computed = type.computed.filter(compute => !vertex.data[compute.name]).reduce((props, compute) => {
+      let resolvedKeys = Object.keys(vertex.data);
+
+      let propsToCompute = type.computed.filter(compute => !resolvedKeys.includes(compute.name));
+
+      let computed = propsToCompute.reduce((props, compute) => {
         return {
           ...props,
           [compute.name]: {


### PR DESCRIPTION
## Motivation

This filter below would break for computed properties that resolved for `0`, `""` or `null`.

```
type.computed.filter(compute => !vertex.data[compute.name])
````

## Approach

Use `vertex.data` keys instead