### PR TITLE
allow a graphql ListValue type or array to be passes as an argument to the @gen directive

### DIFF
--- a/src/dispatch.ts
+++ b/src/dispatch.ts
@@ -17,7 +17,7 @@ export interface DispatchMethod<TContext> {
   (context: TContext, args: unknown[]): unknown;
 }
 
-export type DispatchArg = string | number | boolean;
+export type DispatchArg = string | number | boolean | string[] | number[];
 
 export interface DispatchOptions<T, TContext> {
   methods: Record<string, DispatchMethod<TContext>>;

--- a/src/dispatch.ts
+++ b/src/dispatch.ts
@@ -17,7 +17,7 @@ export interface DispatchMethod<TContext> {
   (context: TContext, args: unknown[]): unknown;
 }
 
-export type DispatchArg = string | number | boolean | string[] | number[];
+export type DispatchArg = string | number | boolean;
 
 export interface DispatchOptions<T, TContext> {
   methods: Record<string, DispatchMethod<TContext>>;

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -718,8 +718,6 @@ function readValue(value: graphql.ASTNode): DispatchArg {
       return parseFloat(value.value);
     case "IntValue":
       return parseInt(value.value);
-    case "ListValue":
-      return value.values.map(readValue) as DispatchArg;
     default:
       throw new Error(`Don't know how to handle argument of kind ${value.kind}`);
   }

--- a/test/graphql.test.ts
+++ b/test/graphql.test.ts
@@ -44,6 +44,12 @@ describe("using graphql", () => {
 
       expect(all).toHaveLength(3);
     });
+
+    it("assigns an id and corresponding typename to each node", () => {
+      let person = graphgen.create("Person");
+      expect(person.id).toBe("1");
+      expect(person.__typename).toBe("Person");
+    })
   });
 
   describe("a global custom generator per field", () => {
@@ -135,6 +141,24 @@ describe("using graphql", () => {
       },
     }).create("Person");
     expect(person.name).toEqual("Bob Dobalina");
+  })
+
+  it("can pass a graphql ListValue as args to the @gen directive", () => {
+    let person = createGraphGen({
+      source:
+      `type Person { name: String! @gen(with: "@fn/join" args: [["Bob", "Smith"]])  }`,
+      generate({ method, args, next }) {
+        if (method === "@fn/join") {
+          if(Array.isArray(args[0])) {
+            return args[0].join(" ");
+          }
+        } else {
+          return next();
+        }
+      },
+    }).create("Person");
+
+    expect(person.name).toBe("Bob Smith");
   })
 
   it("can use a chain of field generators", () => {


### PR DESCRIPTION
## Motivation

At the moment passing an array or `ListValue` type from graphql, e.g.

`status: String @gen(with: "@faker/random.arrayElement" args: [["Deprecated", "Current"]])`

Causes the error

> Don't know how to handle argument of kind ListValue

## Approach

Check `kind` in `genOf` and map the values