### PR TITLE
read null values from graphql args.

### DIFF
--- a/src/dispatch.ts
+++ b/src/dispatch.ts
@@ -17,7 +17,7 @@ export interface DispatchMethod<TContext> {
   (context: TContext, args: unknown[]): unknown;
 }
 
-export type DispatchArg = string | number | boolean;
+export type DispatchArg = string | number | boolean | null;
 
 export interface DispatchOptions<T, TContext> {
   methods: Record<string, DispatchMethod<TContext>>;

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -720,6 +720,8 @@ function readValue(value: graphql.ASTNode): DispatchArg {
       return parseFloat(value.value);
     case "IntValue":
       return parseInt(value.value);
+    case "NullValue":
+      return null;
     default:
       throw new Error(`Don't know how to handle argument of kind ${value.kind}`);
   }

--- a/test/graphql.test.ts
+++ b/test/graphql.test.ts
@@ -159,7 +159,23 @@ describe("using graphql", () => {
     }).create("Person");
 
     expect(person.name).toBe("Bob Smith");
-  })
+  });
+
+  it("can pass a graphql NullValue as args to the @gen directive", () => {
+    let person = createGraphGen({
+      source:
+        `type Person { name: String! @gen(with: "@fn/string" args: [null])  }`,
+      generate({ method, args, next }) {
+        if (method === "@fn/string") {
+          return args.map(String).join();
+        } else {
+          return next();
+        }
+      },
+    }).create("Person");
+
+    expect(person.name).toBe("null");
+  });
 
   it("can use a chain of field generators", () => {
     let name: Generate = ({ method, next }) =>


### PR DESCRIPTION
## Motivation
For whatever reason, sometimes you need to pass null arguments to faker. E.g.

```graphql
@gen(with: "@faker/image.business", args: [null,null, true])
```

## Approach

This just maps GraphQL `NullValue` to JavaScript `null`