### PR TITLE
Allow presets for "many" fields

### DIFF
--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -225,12 +225,10 @@ directive @computed on FIELD_DEFINITION
         if (ref) {
           let target = expect(ref.typenames[0], types);
           let relationship = expect(ref.key, relationships);
+          let targetPreset = Array.isArray(value) ? value.map(content => transform(target, content)) : transform(target, value as Record<string, unknown>);
           return {
             ...transformed,
-            [relationship.name]: transform(
-              target,
-              preset[fieldname] as Record<string, unknown> | undefined,
-            ),
+            [relationship.name]: targetPreset,
           };
         } else {
           return {

--- a/test/graphql.test.ts
+++ b/test/graphql.test.ts
@@ -79,6 +79,19 @@ describe("using graphql", () => {
         occupation: "Person.occupation is a String",
       });
     });
+
+    it('can preset "many" relationships', () => {
+      let person = createGraphGen({
+        source: `
+type Person { name: String! accounts: [Account] }
+type Account { name: String! }`,
+      }).create("Person", {
+        accounts: [{
+          name: `Checking`,
+        }]
+      });
+      expect(person.accounts[0]?.name).toEqual("Checking");
+    });
   });
 
   it("can generate values for something that is nullable", () => {


### PR DESCRIPTION
## Motivation
We are transforming only subhashes which implies that you can only have "one" relationships. However, you can also have "many" relationships in which the preset will be array data. In other words, this should ensure that a person has an account named "checking".

```ts
create("Person", {
  accounts: [{name: "Checking" }],
});
```
It may have more accounts, but it will _at least_ contain that one.

## Approach

Any arrays we find in the preset, map them them over the transform instead of treating them like records to themselves be transformed.