### PR TITLE
Allow array presets

### DIFF
--- a/src/graph.ts
+++ b/src/graph.ts
@@ -240,7 +240,7 @@ export function createVertex(
 
     let excluded = [source.id];
 
-    for (let i = existing.length; i < size; i++) {
+    for (let i = existing.length; i < Math.max(size, presets.length + existing.length); i++) {
       let edgeType = graph.types.edge[relationship.type];
 
       // At this point, we have a choice to make. We could create a new vertex
@@ -273,7 +273,8 @@ export function createVertex(
         Math.pow(1 - (relationship.affinity ?? 0), population.length);
 
       let [targetId, exists] = (function (): [number, boolean] {
-        if (population.length > excluded.length && graph.seed() < affinity) {
+        let hasPreset = i - existing.length < presets.length;
+        if (!hasPreset && (population.length > excluded.length && graph.seed() < affinity)) {
           while (true) {
             let vertex = uniform(population as [Vertex, ...Vertex[]]).sample(
               graph.seed,
@@ -317,7 +318,7 @@ export function createVertex(
           }
         }
 
-        createVertex(graph, getTargetType(), presets[i], targetId, edge);
+        createVertex(graph, getTargetType(), presets[i - existing.length], targetId, edge);
       }
     }
   }

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -77,7 +77,6 @@ directive @computed on FIELD_DEFINITION
   let schema = graphql.extendSchema(prelude, graphql.parse(options.source));
 
   let { types, edges, relationships } = analyze(schema);
-  //console.dir({ types, edges, relationships }, { depth: 5 });
 
   let fieldgen = createFieldGenerate(
     seed,
@@ -225,7 +224,9 @@ directive @computed on FIELD_DEFINITION
         if (ref) {
           let target = expect(ref.typenames[0], types);
           let relationship = expect(ref.key, relationships);
-          let targetPreset = Array.isArray(value) ? value.map(content => transform(target, content)) : transform(target, value as Record<string, unknown>);
+          let targetPreset = Array.isArray(value)
+            ? value.map((content) => transform(target, content))
+            : transform(target, value as Record<string, unknown>);
           return {
             ...transformed,
             [relationship.name]: targetPreset,

--- a/test/preset.test.ts
+++ b/test/preset.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it } from "./suite.ts";
 
-import { constant, createGraph, createVertex, Graph } from "../mod.ts";
+import { constant, createGraph, createVertex, Graph, normal } from "../mod.ts";
 
 describe("preseeding data", () => {
   let graph: Graph;
@@ -115,4 +115,70 @@ describe("preseeding data", () => {
       }]);
     });
   });
+});
+
+it("will override a decision to use an existing vertex based on affinity if a preset is present", () => {
+  let graph = createGraph({
+    types: {
+      vertex: [{
+        name: "Component",
+        data() {
+          return {
+            description: "Generate Component Data",
+            sample(seed) {
+              return `Component ${seed()}`;
+            },
+          };
+        },
+        relationships: [{
+          type: "subComponents",
+          direction: "from",
+          size: normal({ mean: 2, standardDeviation: 1, min: 0 }),
+          affinity: .5,
+        }, {
+          type: "consumes",
+          direction: "from",
+          size: normal({ mean: 1, standardDeviation: 1, min: 1 }),
+          affinity: 1
+        }],
+      }, {
+        name: "API",
+        data() {
+          return {
+            description: "Genate API Data",
+            sample(seed) {
+              return {
+                name: `API ${seed()}`
+              };
+            },
+          };
+        },
+        relationships: [{
+          type: "consumes",
+          direction: "to",
+          size: normal({ mean: 3, standardDeviation: 1, min: 0 }),
+          affinity: .1,
+        }]
+      }],
+      edge: [{
+        name: "subComponents",
+        from: "Component",
+        to: "Component",
+      }, {
+        name: "consumes",
+        from: "Component",
+        to: "API",
+      }]
+    },
+  });
+
+  let vertex = createVertex(graph, "Component", {
+    consumes: [{
+      name: 'github-enterprise'
+    }],
+  });
+
+  let edges = (graph.from[vertex.id] ?? []).filter(edge => edge.type === 'consumes');
+  let consumedApis = edges.map(edge => graph.vertices[edge.to].data.name);
+  expect(consumedApis).toContain("github-enterprise");
 });


### PR DESCRIPTION
## Motivation

The graphql DSL assumes that all presets are nested hashes. However, for "many" relationships, these are collections. 

## Approach
When we transform a preset, we have to make sure and map any arrays we find in it are themselves transformed, so we map transform over the array.