### PR TITLE
Match release branches on verify workflow

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -6,13 +6,13 @@
 # This workflow will install Deno then run Deno lint and test.
 # For more information see: https://github.com/denoland/setup-deno
 
-name: Lint and Test
+name: Verify
 
 on:
   push:
-    branches: [v0]
+    branches: v[0-9]
   pull_request:
-    branches: [v0]
+    branches: v[0-9]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Motivation

We were only running verification checks on the v0 branch, but that was not great when we released 1.0

## Approach

Run the `verify` workflow on all vX branches (0-9)