### PR TITLE
unwrap non-nullable type for isListType check

### DIFF
--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -678,8 +678,16 @@ function directiveOf(field: GQLField, name: string) {
   )[0];
 }
 
+function isListType(type: GQLField["type"]): boolean {
+  if (graphql.isNonNullType(type)) {
+    return isListType(type.ofType);
+  }
+
+  return graphql.isListType(type);
+}
+
 function arityOf(field: GQLField): Arity {
-  if (graphql.isListType(field.type)) {
+  if (isListType(field.type)) {
     return {
       has: "many",
       size: sizeOf(field),

--- a/test/graphql.test.ts
+++ b/test/graphql.test.ts
@@ -372,6 +372,16 @@ type Bank { name: String! }
     expect(person.account.bank.name).toEqual("US Bank");
   });
 
+  it("should create an array non-nullable list type fields", () => {
+    let person = createGraphGen({
+      source: `
+type Person { name: String! accounts: [Account]! }
+type Account { name: String! }`,
+    }).create("Person");
+
+    expect(Array.isArray(person.accounts)).toBe(true);
+  });
+
   it.ignore("forbids putting a @size on single relationships", () => {
     expect(() => {
       createGraphGen({


### PR DESCRIPTION
## Motivation

`graphql.isListType` is returning false for non-nullable fields, e.g.

`type Person { name: String! accounts: [Account]! }`

## Approach

If the field is non-nullable then you need to unwrap it further by accessing `type.ofType`