### PR TITLE
ban __typename and id from ComputeMap type

### DIFF
--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -49,10 +49,15 @@ export interface GenerateInfo {
 //deno-lint-ignore no-explicit-any
 type DefaultComputeMap = Record<string, (node: any) => any>;
 
+type BannedTypeKeys = '__typename' | 'id';
+
 type ComputeMap<API> = {
   [K in keyof API]: {
-    //deno-lint-ignore no-explicit-any
-    [P in keyof API[K] as `${K & string}.${P & string}`]?: (o: API[K]) => any;
+    [
+      P in keyof API[K] as P extends BannedTypeKeys ? never
+        : `${K & string}.${P & string}`
+      //deno-lint-ignore no-explicit-any
+    ]?: (o: API[K]) => any;
   };
 }[keyof API];
 

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -49,12 +49,12 @@ export interface GenerateInfo {
 //deno-lint-ignore no-explicit-any
 type DefaultComputeMap = Record<string, (node: any) => any>;
 
-type BannedTypeKeys = '__typename' | 'id';
+type BannedComputeMapKeys = '__typename' | 'id';
 
 type ComputeMap<API> = {
   [K in keyof API]: {
     [
-      P in keyof API[K] as P extends BannedTypeKeys ? never
+      P in keyof API[K] as P extends BannedComputeMapKeys ? never
         : `${K & string}.${P & string}`
       //deno-lint-ignore no-explicit-any
     ]?: (o: API[K]) => any;

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -49,7 +49,7 @@ export interface GenerateInfo {
 //deno-lint-ignore no-explicit-any
 type DefaultComputeMap = Record<string, (node: any) => any>;
 
-type BannedComputeMapKeys = '__typename' | 'id';
+type BannedComputeMapKeys = "__typename" | "id";
 
 type ComputeMap<API> = {
   [K in keyof API]: {


### PR DESCRIPTION
## Motivation

We don't want to allow `__typename` or `id` for the `ComputeMap` type.

As `__typename` is alphabetically the first type and unlikely to be usurped by anything and it appears first in the intellisense.

![Screenshot 2022-08-04 at 14 16 38](https://user-images.githubusercontent.com/118328/182857412-3e43c129-3279-4df4-8749-23acdfe54e65.png)

This PR filters out those keys from `ComputeMap`

## Approach

Create a `BannedComputeMapKeys` and filter those out;

## Screenshots

![Screenshot 2022-08-04 at 14 24 19 (3)](https://user-images.githubusercontent.com/118328/182858194-d78b3df6-c2d1-4df0-8ea6-5faffbdc7d2d.png)
