### PR TITLE
✨Add capability to cache graph generation

### DIFF
--- a/src/alea.ts
+++ b/src/alea.ts
@@ -1,0 +1,20 @@
+import { Alea } from "./deps.ts";
+
+export interface Alea {
+  (): number;
+  importState(state: number[]): void;
+  exportState(): number[];
+}
+
+export function createAlea(seed?: string) {
+  return (seed ? new Alea(seed) : new Alea()) as Alea;
+}
+
+export function isAlea(value: unknown): value is Alea {
+  if (value != null) {
+    //deno-lint-ignore no-explicit-any
+    return typeof ((value as any).importState) === "function";
+  } else {
+    return false;
+  }
+}

--- a/src/alea.ts
+++ b/src/alea.ts
@@ -6,15 +6,6 @@ export interface Alea {
   exportState(): number[];
 }
 
-export function createAlea(seed?: string) {
-  return (seed ? new Alea(seed) : new Alea()) as Alea;
-}
-
-export function isAlea(value: unknown): value is Alea {
-  if (value != null) {
-    //deno-lint-ignore no-explicit-any
-    return typeof ((value as any).importState) === "function";
-  } else {
-    return false;
-  }
+export function createAlea(seed?: string): Alea {
+  return seed ? new Alea(seed) : new Alea();
 }

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,0 +1,106 @@
+import type { Alea } from "./alea.ts";
+import type { Graph, Vertex } from "./graph.ts";
+
+// We have to use `hash.js` because it is synchronous
+// we can revisit when we make graph generation lazy / async.
+import { hash } from "./deps.ts";
+import { assert } from "./deps.ts";
+
+interface Cache {
+  create(typename: string, preset: unknown, onMiss: () => Vertex): Vertex;
+}
+
+export const cachekey = createCacheKey();
+
+export type CacheValue =
+  & Pick<Graph, "roots" | "vertices" | "from" | "to" | "currentId">
+  & {
+    vertexId: number;
+    prngState: number[];
+  };
+
+export type CacheStorage = Pick<Map<string, CacheValue>, "get" | "set">;
+
+interface CacheOptions {
+  source: string;
+  seed: Alea;
+  graph: Graph;
+  storage: CacheStorage;
+}
+export function createCache(options: CacheOptions): Cache {
+  let { graph, seed, storage } = options;
+  let key = cachekey.schema(options.source);
+
+  return {
+    create(typename, preset, onMiss) {
+      let { next, value: thisKey } = key.create(typename, preset);
+
+      let vertex: Vertex;
+      if (storage.get(thisKey)) {
+        let cacheValue = storage.get(thisKey);
+        assert(!!cacheValue);
+        let { roots, vertices, from, to, currentId, prngState } = cacheValue;
+        seed.importState(prngState);
+        Object.assign(graph, {
+          currentId,
+          roots,
+          vertices,
+          from,
+          to,
+        });
+        vertex = graph.vertices[cacheValue.vertexId];
+        assert(
+          !!vertex,
+          `cache hit for key ${key}, but vertex was not in the graph!`,
+        );
+      } else {
+        vertex = onMiss();
+        let { roots, vertices, from, to, currentId } = graph;
+        storage.set(thisKey, {
+          prngState: seed.exportState(),
+          currentId,
+          vertexId: vertex.id,
+          roots,
+          vertices,
+          from,
+          to,
+        });
+      }
+      key = next;
+      return vertex;
+    },
+  };
+}
+
+export const NullCache: Cache = {
+  create: (_typename, _preset, onMiss) => onMiss(),
+};
+
+export interface CacheKey {
+  ancestors: string[];
+  schema(source: string): CacheKey;
+  create(typename: string, preset?: unknown): { next: CacheKey; value: string };
+}
+
+function createCacheKey(
+  provenance: string[] = [],
+  versionId: string[] = [],
+): CacheKey {
+  return {
+    ancestors: provenance,
+    schema(source) {
+      let newVersionId = hash.sha256().update(source).digest("hex");
+      return createCacheKey(provenance, [newVersionId]);
+    },
+    create(typename, preset) {
+      let args = preset != null ? [typename, preset] : [typename];
+      let key = provenance.concat(
+        `create(${args.map((arg) => JSON.stringify(arg)).join(",")})`,
+      );
+      return {
+        value: [key.join("->")].concat(versionId).join("@"),
+        next: createCacheKey(key, versionId),
+      };
+    },
+  };
+}

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -1,4 +1,9 @@
 export * as graphql from "https://esm.sh/graphql@16.5.0/graphql";
 export * from "https://deno.land/x/continuation@0.1.0/mod.ts";
+export * from "https://deno.land/x/seed@1.0.0/index.ts";
 export { assert } from "https://deno.land/std@0.145.0/testing/asserts.ts";
 export { default as globToRegExp } from "https://esm.sh/glob-to-regexp@0.4.1";
+export { default as hash } from "https://esm.sh/hash.js@1.1.7";
+
+import * as alea from "https://esm.sh/alea@1.0.1";
+export const Alea = alea.default;


### PR DESCRIPTION
## Motivation
Graph generation for large graphs can be very slow. For example, on some projects, the generation time can be up to thirty seconds. This introduces a lot of latency in restarting any environment that requires simulated data. However, most of the time this latency is completely and totally unecessary because the graph generation is pseudo-random and thus deterministic. In other words, we're spending billions of intense CPU cycles, and hours of developer time regenerating the _same thing over and over again_!!

This implements the possibility of caching a graphgen by passing it a `storage` API that it can use to put values into and pull values out of. For each call to `create()` Graphgen will store the resulting graph using a key derived from

1. the arguments to `create()`
2. a hash of the schema source
3. all prior calls to `create()`

This allows us to have a single cache store multiple generations paths for multiple different schema versions without conflicting.

For example, let's say you have a schema source

```graphql
type Person {
  name: String!
}
```
and that for arguments sake, its sha-256 hash is `"abc"`. The following generation sequence:

```ts
create("Person", { name: "Bob" });
create("Person", { name: "Alice" });
```

will cache two versions of the graph at the following keys:

```
1. create("Person", {"name": "Bob" })@abc
2. create("Person", {"name": "Bob" }) -> create("Person", { "name": "Alice" })@abc
```

This means that it will disambiguate it from the inverse generation
sequence:

```ts
create("Person, { name: "Alice" });
create("Person, { name: "Bob" });
```

which would generate keys:

```
1. create("Person", {"name": "Alice" })@abc
2. create("Person", {"name": "Alice" }) -> create("Person", { "name": "Bob" })@abc
```

By the same token, the hash of the schema is appended to each key so that different schemas shared different spaces. That way, you can change the schema, or switch branches that contain schema changes, without having to blow away your cache.

PRNG (pseudo random number generator) state
==========

We need the cache to save off the entire state of graph generator which includes the pseudo random number generator. In other words, no matter where you save off the cache, you should be able to resume on top of it and still get the same results. However, finding a PRNG that had this property was [difficult](https://github.com/tc39/proposal-seeded-random/issues/17) but I eventually stumbled on the [`Alea`](https://github.com/coverslide/node-alea)  package which is a PRNG that has explicit support for restoring serialized state.

In order to make this works, this migrates the PRNG used by graphgen from the generic `seed` package that supports a multiplicity of algorithms to just the ALEA algorithm.

A note on synchronicity
=================

This storage API must be synchronous because graphgen itself is synchronous. However, we should revisit making this api async if we can settle on a way to make graphgen asynchronous and lazy in the future.

A follow-on consequence of making this API synchronous is that we are forced to use the deprecated `createHash()` function because it is synchronous while the replacement API which, while compatible with the Web Crypto standard, is asynchronous.