### PR TITLE
Expose `Graph` object underlying the graphgen

### DIFF
--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -1,7 +1,7 @@
 import type { Seed } from "./distribution.ts";
 import { seedrandom } from "./seedrandom.ts";
 import { assert, evaluate, graphql, shift } from "./deps.ts";
-import { createGraph, createVertex, Vertex } from "./graph.ts";
+import { createGraph, createVertex, Graph, Vertex } from "./graph.ts";
 import { normal, weighted } from "./distribution.ts";
 
 import { DispatchArg } from "./dispatch.ts";
@@ -21,6 +21,7 @@ export type Preset<T> = T extends object ? {
 
 //deno-lint-ignore no-explicit-any
 export interface GraphGen<API = Record<string, any>> {
+  graph: Graph;
   create<T extends string & keyof API>(
     typename: T,
     preset?: Preset<API[T]>,
@@ -281,6 +282,7 @@ directive @computed on FIELD_DEFINITION
   }
 
   return {
+    graph,
     create,
     all,
     createMany(typename, amount) {


### PR DESCRIPTION
## Motivation
Some applications use the raw graph directly. While the new SDL based graphgen aims to replace all usages eventually, this is not currently the case.

## Approach
This exposes the direct graph object so that it can be used directly.