### PR TITLE
Lookup individual nodes from anywhere.

### DIFF
--- a/src/graphql/graphgen.ts
+++ b/src/graphql/graphgen.ts
@@ -32,11 +32,15 @@ export interface GraphGen<API = Record<string, any>> {
     typename: T,
     preset?: Preset<API[T]>,
   ): Node & API[T];
-  all<T extends string & keyof API>(typename: T): Iterable<Node & API[T]>;
+  all<T extends string & keyof API>(typename: T): Collection<Node & API[T]>;
   createMany<T extends string & keyof API>(
     typename: T,
     amount: number,
   ): Iterable<Node & API[T]>;
+}
+
+export interface Collection<T> extends Iterable<T> {
+  get(id: string): T | undefined;
 }
 
 export interface Generate {
@@ -274,11 +278,19 @@ directive @computed on FIELD_DEFINITION
     return transformed;
   }
 
-  function all<T extends string & keyof API>(typename: T) {
+  function all<T extends string & keyof API>(
+    typename: T,
+  ): Collection<Node & API[T]> {
     return {
       *[Symbol.iterator]() {
         for (let id in graph.roots[typename]) {
           yield toNode<API[typeof typename]>(graph.roots[typename][id]);
+        }
+      },
+      get(id) {
+        let vertex = graph.roots[typename][Number(id)];
+        if (vertex) {
+          return toNode(vertex);
         }
       },
     };

--- a/test/graphql.test.ts
+++ b/test/graphql.test.ts
@@ -47,6 +47,11 @@ describe("using graphql", () => {
       expect(all).toHaveLength(3);
     });
 
+    it("can lookup a single node by type and id", () => {
+      let person = graphgen.create("Person");
+      expect(graphgen.all("Person").get(person.id)).toBe(person);
+    });
+
     it("assigns an id and corresponding typename to each node", () => {
       let person = graphgen.create("Person");
       expect(person.id).toBe("1");


### PR DESCRIPTION
## Motivation
We need to be able to lookup a node from anywhere in a hierarchy so that it can be loaded lazily.

## Approach
This adds a `get()` method onto the return value of `factory.all()` to find the node. It can also be used for implementing the Relay `node {}` query.