### PR TITLE
Implement a basic CLI build

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -1,0 +1,53 @@
+# This workflow will install Deno then run Deno lint and test.
+# For more information see: https://github.com/denoland/setup-deno
+
+name: Release CLI
+
+on:
+  push:
+    tags:
+      - "graphgen-cli-v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+
+      - name: setup deno
+        # uses: denoland/setup-deno@v1
+        uses: denoland/setup-deno@004814556e37c54a2f6e31384c9e18e983317366
+        with:
+          deno-version: v1.25.x
+
+      - name: Get Version
+        id: vars
+        run: echo ::set-output name=version::$(echo ${{github.ref_name}} | sed 's/^v//')
+
+
+      - name: Setup Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14.x
+          registry-url: https://registry.npmjs.com
+
+      - name: Build
+        run: deno task build:cli
+        env:
+          VERSION: ${{steps.vars.outputs.version}}
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          # note you'll typically need to create a personal access token
+          # with permissions to create releases in the other repo
+          token: ${{ secrets.FRONTSIDEJACK_GITHUB_TOKEN }}
+          files: build/cli/*
+          fail_on_unmatched_files: true
+        env:
+          GITHUB_REPOSITORY: thefrontside/graphgen

--- a/cli/main.ts
+++ b/cli/main.ts
@@ -1,0 +1,1 @@
+console.log("Hello World");

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,11 @@
 {
   "tasks": {
-    "build:npm": "deno run -A tasks/build-npm.ts"
+    "build:npm": "deno run -A tasks/build-npm.ts",
+    "build:cli:windows": "deno compile -o build/cli/graphgen-x86_64-pc-windows-msvc.exe --target x86_64-pc-windows-msvc --allow-read --allow-net cli/main.ts",
+    "build:cli:linux": "deno compile -o build/cli/graphgen-x86_64-unknown-linux-gnu --target x86_64-unknown-linux-gnu --allow-read --allow-net cli/main.ts",
+    "build:cli:macos-m1": "deno compile -o build/cli/graphgen-aarch64-apple-darwin --target aarch64-apple-darwin --allow-read --allow-net cli/main.ts",
+    "build:cli:macos-intel": "deno compile -o build/cli/graphgen-x86_64-apple-darwin --target x86_64-apple-darwin --allow-read --allow-net cli/main.ts",
+    "build:cli": "deno task build:cli:windows && deno task build:cli:linux && deno task build:cli:macos-m1 && deno task build:cli:macos-intel"
   },
   "lint": {
     "rules": {

--- a/src/graphql/analyze.ts
+++ b/src/graphql/analyze.ts
@@ -309,11 +309,11 @@ function sizeOf(field: GQLField): Size {
   if (directive) {
     assert(directive.arguments, "@size must have arguments");
     let meanArg = directive.arguments?.find((arg) => arg.name.value === "mean");
-    let mean = parseInt((meanArg?.value as graphql.IntValueNode).value ?? 5);
+    let mean = parseInt((meanArg?.value as graphql.IntValueNode)?.value ?? 5);
     let minArg = directive.arguments?.find(({ name }) => name.value === "min");
-    let min = parseInt((minArg?.value as graphql.IntValueNode).value ?? 0);
+    let min = parseInt((minArg?.value as graphql.IntValueNode)?.value ?? 0);
     let maxArg = directive.arguments?.find(({ name }) => name.value === "max");
-    let max = parseInt((maxArg?.value as graphql.IntValueNode).value ?? 10);
+    let max = parseInt((maxArg?.value as graphql.IntValueNode)?.value ?? 10);
     let standardDeviationArg = directive.arguments?.find(({ name }) =>
       name.value === "standardDeviation"
     );


### PR DESCRIPTION
## Motivation

We want a way to be able to visually represent a graphgen factory so that you can see what kinds of data it will generate for a given set of inputs.

## Approach

We can distribute the tool as a CLI compiled for each individual platform using `deno compile`.

This creates a CLI build for each platform and compiles it with only the ability to access the network, and also to allow reading from the filesystem. Binaries are created for each platform, and uploaded as a github release on any tag starting with `graphgen-cli-vx.x.x`