### PR TITLE
Use graphgen factory with analysis on it.

### DIFF
--- a/cli/example/package.json
+++ b/cli/example/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "dependencies": {
     "@faker-js/faker": "7.5.0",
-    "@frontside/graphgen": "1.6.0"
+    "@frontside/graphgen": "1.7.0"
   }
 }


### PR DESCRIPTION
## Motivation

Our inspector application requires a version of graphgen that contains the type analysis, which was introduced with graphgen `1.7.0`. 
<!-- REQUIRED
  Why are you introducing this change? Why is this change necessary? What
  are you trying to achieve with this change?
  If you have a relevant issue, add a link directly to the URL here.
 -->

## Approach
This updates the example factory to use that instead.

### TODOs and Open Questions

- [ ] We should have some sort of verification process that checks the version of graphgen for compatibility.
