### PR TITLE
Handle default commonjs exports

### DIFF
--- a/cli/main.ts
+++ b/cli/main.ts
@@ -24,7 +24,8 @@ async function parseOptions(
 ): Promise<MainOptions> {
   let modulePath = path.resolve(getModuleName(args.factory));
   let require = createRequire(path.dirname(modulePath));
-  let factory = require(modulePath);
+  let mod = require( modulePath);
+  let factory = mod.default ?? mod;
 
   //TODO: validate that the factory is a Graphgen object and is define, etc...
 


### PR DESCRIPTION
## Motivation
CJS has both the case where the export object *is* the default, and also where there is a module export called "default" and we have to handle them both.

## Approach
This just checks and if there is a property called `default` we use that instead. Again, we need to have some form of validation on the export itself but this will be flexible for now.
