### PR TITLE
Make start command run local development

### DIFF
--- a/website/netlify.toml
+++ b/website/netlify.toml
@@ -4,7 +4,7 @@
   publish = "dist/"
 
 [dev]
-  command = "npm start"
+  command = "npm run dev"
   targetPort = 3000
   framework = "#custom"
 

--- a/website/package.json
+++ b/website/package.json
@@ -4,8 +4,8 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
+    "start": "npm exec netlify dev",
     "dev": "astro dev",
-    "start": "astro dev",
     "check": "astro check && tsc",
     "build": "astro build",
     "preview": "astro preview",


### PR DESCRIPTION
## Motivation

With the integration to our website, you need to use a local netlify development environment to do local dev. This is really cool in that it simulates how the app will run in production, but you have to know to run `npx netlify dev`

## Approach

This makes that command the default `start` script, so that `npm start` goes through netlify.

## Screenshots

![2022-12-13 09 11 04](https://user-images.githubusercontent.com/4205/207370714-34a7e6b7-8f97-4c31-a106-eec0dc7cff4b.gif)
