### PR TITLE
Set width and height appropriately for our non-square logo.

### DIFF
--- a/www/components/Header.tsx
+++ b/www/components/Header.tsx
@@ -28,9 +28,9 @@ function Logo() {
     <a href="." class="flex mr-3 items-center">
       <img
         src="logo.svg"
-        alt="GraphGen log"
+        alt="GraphGen logo"
         width={40}
-        height={40}
+        height={46}
       />
     </a>
   );


### PR DESCRIPTION
## Motivation
Our FS logo is not square, so having a square rectangle causes it to flicker between the expected size, vs the actual size when it pops in.
## Approach

Explicitly set height to match logo.