### PR TITLE
Make `createDispatch()` also a generate function

### DIFF
--- a/src/graphql/graphgen.ts
+++ b/src/graphql/graphgen.ts
@@ -1,62 +1,28 @@
 import type { Seed } from "../distribution.ts";
-import type { DispatchArg, Field, Reference, Type } from "./types.ts";
+import type {
+  Collection,
+  Field,
+  Generate,
+  GenerateInfo,
+  GraphGen,
+  Node,
+  Preset,
+  Reference,
+  Type,
+} from "./types.ts";
 
 import { assert, evaluate, graphql, shift } from "../deps.ts";
-import { createGraph, createVertex, Graph, Vertex } from "../graph.ts";
+import { createGraph, createVertex, Vertex } from "../graph.ts";
 import { normal, weighted } from "../distribution.ts";
 import { CacheStorage, createCache, NullCache } from "./cache.ts";
 import { Alea, createAlea } from "../alea.ts";
-import { Analysis, analyze } from "./analyze.ts";
+import { analyze } from "./analyze.ts";
 import { expect } from "./expect.ts";
 
 export * from "./dispatch.ts";
 export type { CacheStorage, CacheValue } from "./cache.ts";
 
-export interface Node {
-  id: string;
-  __typename: string;
-}
-
 type NonOverridableKeys = "__typename" | "id";
-
-//deno-lint-ignore ban-types
-export type Preset<T> = T extends object ? {
-    [P in keyof T as P extends NonOverridableKeys ? never : P]?: Preset<T[P]>;
-  }
-  : T;
-
-//deno-lint-ignore no-explicit-any
-export interface GraphGen<API = Record<string, any>> {
-  graph: Graph;
-  create<T extends string & keyof API>(
-    typename: T,
-    preset?: Preset<API[T]>,
-  ): Node & API[T];
-  all<T extends string & keyof API>(typename: T): Collection<Node & API[T]>;
-  createMany<T extends string & keyof API>(
-    typename: T,
-    amount: number,
-  ): Iterable<Node & API[T]>;
-  analysis: Analysis;
-}
-
-export interface Collection<T> extends Iterable<T> {
-  get(id: string): T | undefined;
-}
-
-export interface Generate {
-  (info: GenerateInfo): unknown;
-}
-
-export interface GenerateInfo {
-  method: string;
-  args: DispatchArg[];
-  typename: string;
-  fieldname: string;
-  fieldtype: string;
-  seed: Seed;
-  next(): unknown;
-}
 
 //deno-lint-ignore no-explicit-any
 type DefaultComputeMap = Record<string, (node: any) => any>;

--- a/test/dispatch.test.ts
+++ b/test/dispatch.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "./suite.ts";
+import type { GenerateInfo } from "../src/graphql/types.ts";
 import { createDispatch } from "../src/graphql/dispatch.ts";
 
 describe("dispatch", () => {
@@ -66,5 +67,24 @@ describe("dispatch", () => {
 
     expect(result.handled).toBe(true);
     expect(result.value).toEqual("Bob Dolubrius Dobalina");
+  });
+
+  it("can be used directly as a function", () => {
+    let dispatch = createDispatch<GenerateInfo>({
+      methods: {
+        "Person.name": () => "Bob",
+      },
+      patterns: {},
+    });
+    let result = dispatch({
+      method: "Person.name",
+      args: [],
+      typename: "Person",
+      fieldname: "name",
+      fieldtype: "String",
+      seed: () => Math.random(),
+      next: () => "Did Not Match",
+    });
+    expect(result).toBe("Bob");
   });
 });


### PR DESCRIPTION
## Motivation
The `Dispatch` API was designed to be able to compose multiple generate middlewares so that they could be used as a single function. However, the dispatch did not actually return a generate function, you still had to wire it up as in this fakergen:

```js
module.exports.fakergen = (info) => {
  const result = dispatch.dispatch(info.method, info, info.args);
  if (result.handled) {
    return result.value;
  } else {
    return info.next();
  }
};
```

But when writing the docs, it occured to me that this was needless ceremony.

## Approach

This makes the dispatch _also_ a generate function so that you can skip this step of manually wrapping it. The thing returned by `createDispatch()` will also be a function in addition to satisfying the `Dispatch` API