### PR TITLE
📄🐛 Fix faker integration recipe

### DIFF
--- a/www/docs/usage/faker.md
+++ b/www/docs/usage/faker.md
@@ -34,7 +34,7 @@ const methods = Object.entries(globalFaker).reduce((methods, [name, mod]) => {
   if (mod) {
     for (const [fn, value] of Object.entries(mod)) {
       if (typeof value === "function") {
-        methods[`@faker/${name}.${fn}`] = ({ faker }, args) => {
+        methods[`@faker/${name}.${fn}`] = (faker, args) => {
           return faker[name][fn](...args);
         };
       }


### PR DESCRIPTION
## Motivation

When setting up a new factory from scratch recently I found out that the docs gave a bad lead. The context is the faker object itself, not an object with a property named `faker`.

## Approach

Fix it!